### PR TITLE
node-http-watch-pipeline-activity to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,6 +10,9 @@ dependencies:
 - name: go-http-quickstart
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.3
+- name: node-http-watch-pipeline-activity
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.2
 - name: rails-shopping-cart
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.3


### PR DESCRIPTION
Promote node-http-watch-pipeline-activity to version 0.0.2