### PR TITLE
rails-shopping-cart to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,4 +15,4 @@ dependencies:
   version: 0.0.2
 - name: rails-shopping-cart
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.3
+  version: 0.0.4


### PR DESCRIPTION
Promote rails-shopping-cart to version 0.0.4